### PR TITLE
Hdf5 copy from ext file

### DIFF
--- a/ADCore/ADApp/pluginSrc/NDFileHDF5.h
+++ b/ADCore/ADApp/pluginSrc/NDFileHDF5.h
@@ -250,6 +250,8 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
 
     std::list<NDFileHDF5AttributeDataset*> attrList;
 
+    asynStatus copyHDF5Object(hdf5::DataSource& src, hid_t dst_root, const std::string& dst_name);
+
     /* HDF5 handles and references */
     hid_t file;
     hid_t dataspace;

--- a/ADCore/ADApp/pluginSrc/NDFileHDF5Layout.cpp
+++ b/ADCore/ADApp/pluginSrc/NDFileHDF5Layout.cpp
@@ -86,7 +86,13 @@ namespace hdf5
   {
   }
 
-  DataSource::DataSource(const DataSource& src) : data_src(src.data_src), val(src.val), datatype(src.datatype), when_to_save(src.when_to_save)
+  DataSource::DataSource(DataSrc_t src, const std::string& file, const std::string& path) :
+      data_src(src), val(""), datatype(int8), when_to_save(OnFileOpen), h5file_file(file), h5file_path(path)
+  {
+  }
+
+  DataSource::DataSource(const DataSource& src) : data_src(src.data_src), val(src.val), datatype(src.datatype), 
+        when_to_save(src.when_to_save), h5file_file(src.h5file_file), h5file_path(src.h5file_path)
   {
   }
 
@@ -100,6 +106,8 @@ namespace hdf5
     this->val = src.val;
     this->datatype = src.datatype;
     this->when_to_save = src.when_to_save;
+    this->h5file_file = src.h5file_file;
+    this->h5file_path = src.h5file_path;
     return *this;
   };
 
@@ -123,6 +131,11 @@ namespace hdf5
     return this->data_src == ndattribute ? true : false;
   }
 
+  bool DataSource::is_src_h5file()
+  {
+    return this->data_src == h5file ? true : false;
+  }
+
   bool DataSource::is_src(DataSrc_t src)
   {
     return this->data_src == src ? true : false;
@@ -131,6 +144,24 @@ namespace hdf5
   std::string DataSource::get_src_def()
   {
     return this->val;
+  }
+  
+  std::string DataSource::get_h5file_file()
+  {
+    if (this->is_src_h5file()) {
+        return this->h5file_file;
+    } else {
+        return "";
+    }
+  }
+
+  std::string DataSource::get_h5file_path()
+  {
+    if (this->is_src_h5file()) {
+        return this->h5file_path;
+    } else {
+        return "";
+    }
   }
 
   DataType_t DataSource::get_datatype()
@@ -174,6 +205,13 @@ namespace hdf5
     if (this->data_src != constant) return;
     this->set_datatype(dtype);
     this->val = str_val;
+  }
+
+  void DataSource::set_h5file_file_path(const std::string& file, const std::string& path)
+  {
+    if (this->data_src != h5file) return;
+    this->h5file_file = file;
+    this->h5file_path = path;    
   }
 
   void DataSource::set_when_to_save(When_t when)
@@ -603,6 +641,17 @@ namespace hdf5
     }
   }
 
+  void Group::set_data_source(DataSource& src)
+  {
+    this->datasource = src;
+  }
+
+  DataSource& Group::data_source()
+  {
+    return this->datasource;
+  }
+
+
   /* ================== Group Class private methods ==================== */
   void Group::_copy(const Group& src)
   {
@@ -610,6 +659,7 @@ namespace hdf5
     this->datasets = src.datasets;
     this->groups = src.groups;
     this->ndattr_default_container = src.ndattr_default_container;
+    this->datasource = src.datasource;
   }
 
   bool Group::name_exist(const std::string& name)
@@ -623,6 +673,7 @@ namespace hdf5
     }
     return false;
   }
+  
 
   Root::Root() : Group()
   {

--- a/ADCore/ADApp/pluginSrc/NDFileHDF5Layout.h
+++ b/ADCore/ADApp/pluginSrc/NDFileHDF5Layout.h
@@ -27,7 +27,8 @@ namespace hdf5
     notset,
     detector,
     ndattribute,
-    constant
+    constant,
+    h5file
   } DataSrc_t;
 
   typedef enum {
@@ -55,6 +56,7 @@ namespace hdf5
       DataSource(DataSrc_t src, const std::string& val);
       DataSource(DataSrc_t src);
       DataSource(DataSrc_t src, DataType_t type);
+      DataSource(DataSrc_t src, const std::string& file, const std::string& path);
       // Copy constructor
       DataSource( const DataSource& src);
       // Assignment operator
@@ -65,11 +67,15 @@ namespace hdf5
       bool is_src_ndattribute();
       bool is_src_constant();
       bool is_src(DataSrc_t src);
+      bool is_src_h5file();
 
       std::string get_src_def(); /** return the string that define the source: either name of NDAttribute or constant value */
       DataType_t get_datatype();
       size_t datatype_size();
       void set_const_datatype_value(DataType_t dtype, const std::string& str_val);
+      void set_h5file_file_path(const std::string& file, const std::string& path);
+      std::string get_h5file_file();
+      std::string get_h5file_path();
 
       void set_when_to_save(When_t when);
       When_t get_when_to_save();
@@ -79,6 +85,8 @@ namespace hdf5
       std::string val;
       DataType_t datatype;
       When_t when_to_save;
+      std::string h5file_file;
+      std::string h5file_path;
   };
 
 
@@ -248,6 +256,9 @@ namespace hdf5
       { out << grp._str_(); return out; }
       std::string _str_();  /** Return a string representation of the object */
 
+      void set_data_source(DataSource& src);
+      DataSource& data_source();
+
       typedef std::map<std::string, Group*> MapGroups_t;
       typedef std::map<std::string, Dataset*> MapDatasets_t;
       typedef std::map<std::string, HardLink*> MapHardLinks_t;
@@ -263,6 +274,7 @@ namespace hdf5
 
     private:
       void _copy(const Group& src);
+      DataSource datasource;
       bool name_exist(const std::string& name);
       bool ndattr_default_container;
       std::map<std::string, Dataset*> datasets;

--- a/ADCore/ADApp/pluginSrc/NDFileHDF5LayoutXML.cpp
+++ b/ADCore/ADApp/pluginSrc/NDFileHDF5LayoutXML.cpp
@@ -537,9 +537,15 @@ namespace hdf5
         h5file_path = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_H5FILE_PATH.c_str());
         if (h5file_file != NULL && h5file_path != NULL) {
             attrval.set_h5file_file_path((const char*)h5file_file, (const char*)h5file_path);
+        } else {
+            LOG4CXX_ERROR(log, "Missing file and path attributes for h5file datasource");
         }
-        xmlFree(h5file_file);
-        xmlFree(h5file_path);        
+        if (h5file_file!= NULL) {
+            xmlFree(h5file_file);
+        }
+        if (h5file_path != NULL) {
+            xmlFree(h5file_path);
+        }
     }
     new_group->set_data_source(attrval);
     return 0;
@@ -634,9 +640,15 @@ namespace hdf5
         h5file_path = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_H5FILE_PATH.c_str());
         if (h5file_file != NULL && h5file_path != NULL) {
             attrval.set_h5file_file_path((const char*)h5file_file, (const char*)h5file_path);
+        } else {
+            LOG4CXX_ERROR(log, "Missing file and path attributes for h5file datasource");
         }
-        xmlFree(h5file_file);
-        xmlFree(h5file_path);        
+        if (h5file_file!= NULL) {
+            xmlFree(h5file_file);
+        }
+        if (h5file_path != NULL) {
+            xmlFree(h5file_path);
+        }
     }
     dset->set_data_source(attrval);
     return 0;

--- a/ADCore/ADApp/pluginSrc/NDFileHDF5LayoutXML.h
+++ b/ADCore/ADApp/pluginSrc/NDFileHDF5LayoutXML.h
@@ -75,6 +75,9 @@ namespace hdf5
       static const std::string ATTR_SRC_CONST;
       static const std::string ATTR_SRC_CONST_VALUE;
       static const std::string ATTR_SRC_CONST_TYPE;
+      static const std::string ATTR_SRC_H5FILE;
+      static const std::string ATTR_SRC_H5FILE_FILE;
+      static const std::string ATTR_SRC_H5FILE_PATH;
       static const std::string ATTR_GRP_NDATTR_DEFAULT;
       static const std::string ATTR_SRC_WHEN;
       static const std::string ATTR_GLOBAL_NAME;
@@ -100,6 +103,7 @@ namespace hdf5
       int process_node();
 
       int process_dset_xml_attribute(DataSource& out);
+      int process_group_xml_attribute(DataSource& out);
       int process_attribute_xml_attribute(Attribute& out);
 
       int parse_root();


### PR DESCRIPTION
Extend XML layout file options to allow copy from other files with new `h5file` source keyword e.g.
```
<hdf5_layout>
  <group name="detector">
    <dataset name="data1" source="detector" det_default="true">
    </dataset>
  </group>
  <group name="test1" source="h5file" file="file.nxs" path="/raw_data_1/detector_1" />
  <group name="test2">
    <dataset name="data1" source="h5file" file="file.nxs" path="/raw_data_1/detector_1/counts" />
  </group>
  <group name="test3" source="h5file" file="file.nxs" path="/raw_data_1" />
</hdf5_layout>
```
