### PR TITLE
Rename SignatureSize to avoid clash with windows.h due to updated SDK in VS2026

### DIFF
--- a/ADSupport/supportApp/GraphicsMagickSrc/magick/signature.c
+++ b/ADSupport/supportApp/GraphicsMagickSrc/magick/signature.c
@@ -86,13 +86,13 @@ MagickExport void FinalizeSignature(SignatureInfo *signature_info)
   high_order=signature_info->high_order;
   count=(long) ((low_order >> 3) & 0x3f);
   signature_info->message[count++]=0x80;
-  if (count <= (SignatureSize-8))
-    (void) memset(signature_info->message+count,0,SignatureSize-8-count);
+  if (count <= (MagickSignatureSize-8))
+    (void) memset(signature_info->message+count,0,MagickSignatureSize-8-count);
   else
     {
-      (void) memset(signature_info->message+count,0,SignatureSize-count);
+      (void) memset(signature_info->message+count,0,MagickSignatureSize-count);
       TransformSignature(signature_info);
-      (void) memset(signature_info->message,0,SignatureSize-8);
+      (void) memset(signature_info->message,0,MagickSignatureSize-8);
     }
   signature_info->message[56]=(unsigned char) (high_order >> 24);
   signature_info->message[57]=(unsigned char) (high_order >> 16);
@@ -491,22 +491,22 @@ MagickExport void UpdateSignature(SignatureInfo *signature_info,
   signature_info->high_order+=(unsigned char) (n >> 29);
   if (signature_info->offset)
     {
-      i=SignatureSize-signature_info->offset;
+      i=MagickSignatureSize-signature_info->offset;
       if (i > (long) n)
         i=(long) n;
       (void) memcpy(signature_info->message+signature_info->offset,message,i);
       n-=i;
       message+=i;
       signature_info->offset+=i;
-      if (signature_info->offset != SignatureSize)
+      if (signature_info->offset != MagickSignatureSize)
         return;
       TransformSignature(signature_info);
     }
-  while (n >= SignatureSize)
+  while (n >= MagickSignatureSize)
   {
-    (void) memcpy(signature_info->message,message,SignatureSize);
-    message+=SignatureSize;
-    n-=SignatureSize;
+    (void) memcpy(signature_info->message,message,MagickSignatureSize);
+    message+=MagickSignatureSize;
+    n-=MagickSignatureSize;
     TransformSignature(signature_info);
   }
   (void) memcpy(signature_info->message,message,n);

--- a/ADSupport/supportApp/GraphicsMagickSrc/magick/signature.h
+++ b/ADSupport/supportApp/GraphicsMagickSrc/magick/signature.h
@@ -17,8 +17,10 @@ extern "C" {
 
 /*
   Define declarations.
+  Cannot use SignatureSize name as a clash with Windows RUNTIME_REPORT_PACKAGE_HEADER
+  structure member
 */
-#define SignatureSize  64
+#define MagickSignatureSize  64
 
 /*
   Typedef declarations.
@@ -34,7 +36,7 @@ typedef struct _SignatureInfo
     offset;
 
   unsigned char
-    message[SignatureSize];
+    message[MagickSignatureSize];
 } SignatureInfo;
 
 /*


### PR DESCRIPTION
RUNTIME_REPORT_PACKAGE_HEADER in winnt.h has a structure member of the same name and a compiel error is generated